### PR TITLE
Updates for Regensburg summer school

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
 # logical_verification_2023
+
 Hitchhiker's Guide to Logical Verification (2023 Edition)
 
-Watch this spot for installation instructions.
+## Installation
+
+The Hitchhiker's Guide PDF document is generated from Lean files in the folder
+`lean/LoVe`. The same folder also contains an exercise sheet for each chapter.
+
+To edit the Lean files, open the `lean` folder as a Lean 4 project [as described
+here](https://leanprover-community.github.io/install/project.html#working-on-an-existing-project).

--- a/lean/.gitignore
+++ b/lean/.gitignore
@@ -1,0 +1,2 @@
+/build/
+/lake-packages/

--- a/lean/LoVe/LoVelib.lean
+++ b/lean/LoVe/LoVelib.lean
@@ -152,29 +152,16 @@ attribute [simp] Int.mul_eq_zero
   List.count x [] = 0 :=
   by rfl
 
-theorem List.countp.go_accum {α : Type} (p : α → Bool) (as : List α) (acc : ℕ) :
-  List.countp.go p as acc = List.countp p as + acc :=
-  by
-    induction as generalizing acc with
-    | nil           => simp [List.countp.go, List.countp]
-    | cons a as' ih =>
-      simp [List.countp, List.countp.go]
-      cases Classical.em (p a) with
-      | inl hp =>
-        simp [hp, ih]
-        ac_rfl
-      | inr hp => simp [hp, ih]
-
 @[simp] theorem List.count_cons {α : Type} [BEq α] (x a : α) (as : List α) :
   List.count x (a :: as) = (bif a == x then 1 else 0) + List.count x as :=
   by
     cases Classical.em (a == x) with
     | inl hx =>
-      rw [List.count, List.countp, List.countp.go, List.countp.go_accum]
+      rw [List.count]
       simp [hx]
       ac_rfl
     | inr hx =>
-      rw [List.count, List.countp, List.countp.go, List.countp]
+      rw [List.count]
       simp [hx]
 
 @[simp] theorem List.count_append {α : Type} [BEq α] (x : α) (as bs : List α) :

--- a/lean/lake-manifest.json
+++ b/lean/lake-manifest.json
@@ -4,15 +4,15 @@
  [{"git":
    {"url": "https://github.com/EdAyers/ProofWidgets4",
     "subDir?": null,
-    "rev": "a0c2cd0ac3245a0dade4f925bcfa97e06dd84229",
+    "rev": "44e6673a20fc0449d003983d1e1f472df40f7107",
     "opts": {},
     "name": "proofwidgets",
-    "inputRev?": "v0.0.13",
+    "inputRev?": "v0.0.15",
     "inherited": true}},
   {"git":
    {"url": "https://github.com/mhuisi/lean4-cli.git",
     "subDir?": null,
-    "rev": "5a858c32963b6b19be0d477a30a1f4b6c120be7e",
+    "rev": "21dac2e9cc7e3cf7da5800814787b833e680b2fd",
     "opts": {},
     "name": "Cli",
     "inputRev?": "nightly",
@@ -20,7 +20,7 @@
   {"git":
    {"url": "https://github.com/leanprover-community/mathlib4",
     "subDir?": null,
-    "rev": "368923da0362e039715c44e27d5a1e8ec02d43c9",
+    "rev": "eec55af474ea5763bc724b24779cba53b23d7d2d",
     "opts": {},
     "name": "mathlib",
     "inputRev?": null,
@@ -28,7 +28,7 @@
   {"git":
    {"url": "https://github.com/gebner/quote4",
     "subDir?": null,
-    "rev": "81cc13c524a68d0072561dbac276cd61b65872a6",
+    "rev": "e75daed95ad1c92af4e577fea95e234d7a8401c1",
     "opts": {},
     "name": "Qq",
     "inputRev?": "master",
@@ -36,7 +36,7 @@
   {"git":
    {"url": "https://github.com/JLimperg/aesop",
     "subDir?": null,
-    "rev": "086c98bb129ca856381d4414dc0afd6e3e4ae2ef",
+    "rev": "1a0cded2be292b5496e659b730d2accc742de098",
     "opts": {},
     "name": "aesop",
     "inputRev?": "master",
@@ -44,7 +44,7 @@
   {"git":
    {"url": "https://github.com/leanprover/std4",
     "subDir?": null,
-    "rev": "61a6507eff4dd71c01e0c7e194bc569d4719a6d3",
+    "rev": "ba5e5e3af519b4fc5221ad0fa4b2c87276f1d323",
     "opts": {},
     "name": "std",
     "inputRev?": "main",

--- a/lean/lean-toolchain
+++ b/lean/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2023-08-19
+leanprover/lean4:v4.0.0


### PR DESCRIPTION
I'd like to provide LoVe as an exercise option for CS-minded people in Regensburg. To that end, I've updated some things:

- Bumped the dependencies to Lean v4.0.0 (the first official, 'stable' release)
- Added installation instructions (i.e., a link to the leanprover-community website)
- Added a .gitignore file.